### PR TITLE
Add image map to allow navigation by clicking boulder on the Map image

### DIFF
--- a/app/_components/Image.js
+++ b/app/_components/Image.js
@@ -20,16 +20,14 @@ function getWidthFromPath(path) {
 }
 
 export default function Image(props) {
-    const { path, alt, hideFullView, useMap } = props;
+    const { path, alt, hideFullView } = props;
     return <div>
         <img
             loading="lazy"
             src={getSmallerSizeImage(path)} srcSet={
                 getSmallerSizeImage(path) + ' 960w, ' +
                 getNormalSizeImage(path) + ' ' + getWidthFromPath(path)
-            } alt={alt || images[path]}
-            useMap={useMap ?? undefined}
-        />
+            } alt={alt || images[path]} />
         {(typeof hideFullView === 'undefined' || !hideFullView || hideFullView === false) && <div><a href={getNormalSizeImage(path)} target="_blank" title={alt || images[path]}>View full size</a></div>}
     </div>
 }

--- a/app/_components/Image.js
+++ b/app/_components/Image.js
@@ -20,14 +20,16 @@ function getWidthFromPath(path) {
 }
 
 export default function Image(props) {
-    const { path, alt, hideFullView } = props;
+    const { path, alt, hideFullView, useMap } = props;
     return <div>
         <img
             loading="lazy"
             src={getSmallerSizeImage(path)} srcSet={
                 getSmallerSizeImage(path) + ' 960w, ' +
                 getNormalSizeImage(path) + ' ' + getWidthFromPath(path)
-            } alt={alt || images[path]} />
+            } alt={alt || images[path]}
+            useMap={useMap ?? undefined}
+        />
         {(typeof hideFullView === 'undefined' || !hideFullView || hideFullView === false) && <div><a href={getNormalSizeImage(path)} target="_blank" title={alt || images[path]}>View full size</a></div>}
     </div>
 }

--- a/app/_components/ImageMap.js
+++ b/app/_components/ImageMap.js
@@ -1,0 +1,45 @@
+"use client";
+import boulders from '@/app/data/boulders.json';
+import images from '@/app/data/images.json';
+
+function getNormalSizeImage(path) {
+    return '/images' + path;
+}
+
+export default function ImageMap(props) {
+    const { path, alt } = props;
+
+    return <div>
+        <svg
+            version="1.1"
+            viewBox="0 0 4800 4132"
+            xmlnsXlink="http://www.w3.org/1999/xlink"
+            xmlns="http://www.w3.org/2000/svg">
+            <title>{alt || images[path]}</title>
+            <g>
+                <image
+                    width="4800"
+                    height="4132"
+                    style={{ "image-rendering": "optimizeSpeed", fill: "#ffffff", "fill-opacity": 1 }}
+                    xlinkHref={getNormalSizeImage(path)}
+                    id="image" />
+
+                {boulders.data.filter((boulder) => boulder.image_map).map((boulder) => {
+                    const { image_map: circle } = boulder
+                    return <a id={`a-${boulder.id.replace(".", "-")}`}
+                        xlinkHref={`/sunset-forest/boulder/${boulder.slug}`}
+                        xlinkTitle={`${boulder.id} ${boulder.name} | Sunset Forest Boulders | CRAGS.HK`}
+                        target="_blank">
+                        <circle
+                            style={{ opacity: 0, fill: "#ffffff", "fill-opacity": 1 }}
+                            id={`path-${boulder.id.replace(".", "-")}`}
+                            cx={circle.cx}
+                            cy={circle.cy}
+                            r={circle.r} />
+                    </a>;
+                })}
+            </g>
+        </svg>
+        {(typeof hideFullView === 'undefined' || !hideFullView || hideFullView === false) && <div><a href={getNormalSizeImage(path)} target="_blank" title={alt || images[path]}>View full size</a></div>}
+    </div>
+}

--- a/app/data/boulders.json
+++ b/app/data/boulders.json
@@ -7,8 +7,9 @@
             "zone": 0,
             "image": "/boulders/beginner/beginner-1-2-w2529w.jpg",
             "image_map": {
-                "coords": "1010,837,20",
-                "shape": "circle"
+                "cx": "4041.7595",
+                "cy": "3348.4988",
+                "r": "78.708763"
             },
             "access": {
                 "link": "https://www.instagram.com/reel/CzXerSWSeYH/?utm_source=ig_web_copy_link&igshid=MzRlODBiNWFlZA==",
@@ -28,8 +29,9 @@
             "zone": 1,
             "image": "/boulders/welcome/welcome-w2826w.jpg",
             "image_map": {
-                "coords": "533,788,18",
-                "shape": "circle"
+                "cx": "2131.7603",
+                "cy": "3149.1033",
+                "r": "76.085136"
             },
             "gps": {
                 "lat": 22.33729,
@@ -43,8 +45,9 @@
             "zone": 1,
             "image": "/boulders/the-crown/the-crown-1-2-w2305w.jpg",
             "image_map": {
-                "coords": "592,681,20",
-                "shape": "circle"
+                "cx": "2363.2629",
+                "cy": "2719.4521",
+                "r": "70.837883"
             },
             "gps": {
                 "lat": 22.33746,
@@ -58,8 +61,9 @@
             "zone": 1,
             "image": "/boulders/spectral/spectral-1-4-w3476w.jpg",
             "image_map": {
-                "coords": "627,648,18",
-                "shape": "circle"
+                "cx": "2502.3149",
+                "cy": "2592.8945",
+                "r": "76.085136"
             },
             "gps": {
                 "lat": 22.33751,
@@ -73,8 +77,9 @@
             "zone": 1,
             "image": "/boulders/viking-table/viking-table-1-w3264w.jpg",
             "image_map": {
-                "coords": "603,548,18",
-                "shape": "circle"
+                "cx": "2407.8645",
+                "cy": "2192.1035",
+                "r": "76.085136"
             },
             "gps": {
                 "lat": 22.33767,
@@ -88,8 +93,9 @@
             "zone": 1,
             "image": "/boulders/tiny/tiny-1-w3024w.jpg",
             "image_map": {
-                "coords": "509,473,20",
-                "shape": "circle"
+                "cx": "2037.9333",
+                "cy": "1887.1394",
+                "r": "83.956009"
             },
             "gps": {
                 "lat": 22.33779,
@@ -103,8 +109,9 @@
             "zone": 1,
             "image": "/boulders/temple/temple-1-w2305w.jpg",
             "image_map": {
-                "coords": "434,681,18",
-                "shape": "circle"
+                "cx": "1731.5928",
+                "cy": "2715.4521",
+                "r": "78.708763"
             },
             "gps": {
                 "lat": 22.33746,
@@ -118,8 +125,9 @@
             "zone": 2,
             "image": "/boulders/frost/frost-1-2-w4032w.jpg",
             "image_map": {
-                "coords": "428,347,17",
-                "shape": "circle"
+                "cx": "1713.9801",
+                "cy": "1390.2632",
+                "r": "76.085136"
             },
             "gps": {
                 "lat": 22.33798,
@@ -133,8 +141,9 @@
             "zone": 2,
             "image": "/boulders/iron-wing/iron-wing-1-w3024w.jpg",
             "image_map": {
-                "coords": "429,383,15",
-                "shape": "circle"
+                "cx": "1711.2274",
+                "cy": "1538.4554",
+                "r": "73.46151"
             },
             "gps": {
                 "lat": 22.33794,
@@ -148,8 +157,9 @@
             "zone": 2,
             "image": "/boulders/the-whale/the-whale-1-4-w4032w.jpg",
             "image_map": {
-                "coords": "440,310,18",
-                "shape": "circle"
+                "cx": "1759.2053",
+                "cy": "1234.4803",
+                "r": "76.085136"
             },
             "gps": {
                 "lat": 22.33805,
@@ -163,8 +173,9 @@
             "zone": 3,
             "image": "/boulders/falcon/falcon-1-2-w4032w.jpg",
             "image_map": {
-                "coords": "390,449,19",
-                "shape": "circle"
+                "cx": "1548.5626",
+                "cy": "1789.9362",
+                "r": "78.708763"
             },
             "gps": {
                 "lat": 22.33783,
@@ -178,8 +189,9 @@
             "zone": 3,
             "image": "/boulders/dragon-head/dragon-head-1-2-w2305w.jpg",
             "image_map": {
-                "coords": "400,487,18",
-                "shape": "circle"
+                "cx": "1594.5406",
+                "cy": "1940.8591",
+                "r": "76.085136"
             },
             "gps": {
                 "lat": 22.33777,
@@ -200,8 +212,9 @@
             "zone": 4,
             "image": "/boulders/destiny/destiny-2-5-w3264w.jpg",
             "image_map": {
-                "coords": "132,422,19",
-                "shape": "circle"
+                "cx": "525.47784",
+                "cy": "1688.3674",
+                "r": "73.46151"
             },
             "access": {
                 "link": "https://www.instagram.com/reel/CzNvNbjSm3p/?utm_source=ig_web_copy_link&igshid=MzRlODBiNWFlZA==",
@@ -221,8 +234,9 @@
             "zone": 4,
             "image": "/boulders/wuji/wuji-1-w2448w.jpg",
             "image_map": {
-                "coords": "295,336,19",
-                "shape": "circle"
+                "cx": "1176.7605",
+                "cy": "1336.1781",
+                "r": "76.085136"
             },
             "gps": {
                 "lat": 22.33801,
@@ -236,8 +250,9 @@
             "zone": 5,
             "image": "/boulders/kaze/kaze-1-w4032w.jpg",
             "image_map": {
-                "coords": "800,568,18",
-                "shape": "circle"
+                "cx": "3200.823",
+                "cy": "2267.5652",
+                "r": "70.837883"
             },
             "gps": {
                 "lat": 22.33764,
@@ -265,8 +280,9 @@
             ],
             "image": "/boulders/the-three-artifacts/the-three-artifacts-4-6-w4032w.jpeg",
             "image_map": {
-                "coords": "910,492,17",
-                "shape": "circle"
+                "cx": "3646.8394",
+                "cy": "1965.0955",
+                "r": "68.214256"
             },
             "gps": {
                 "lat": 22.33776,
@@ -280,8 +296,9 @@
             "zone": 6,
             "image": "/boulders/strength/strength-1-w4032w.jpg",
             "image_map": {
-                "coords": "650,233,19",
-                "shape": "circle"
+                "cx": "2597.3892",
+                "cy": "934.01062",
+                "r": "68.214256"
             },
             "gps": {
                 "lat": 22.33817,
@@ -295,8 +312,9 @@
             "zone": 6,
             "image": "/boulders/the-great-sail/the-great-sail-3-4-w4032w.jpg",
             "image_map": {
-                "coords": "814,380,21",
-                "shape": "circle"
+                "cx": "3248.6719",
+                "cy": "1512.5846",
+                "r": "68.214256"
             },
             "access": {
                 "link": "https://www.instagram.com/reel/CzNgP9fyiLs/?utm_source=ig_web_copy_link&igshid=MzRlODBiNWFlZA==",
@@ -316,8 +334,9 @@
             "zone": 6,
             "image": "/boulders/ghost-blade/ghost-blade-1-3-w4032w.jpg",
             "image_map": {
-                "coords": "831,316,17",
-                "shape": "circle"
+                "cx": "3318.886",
+                "cy": "1259.3402",
+                "r": "68.214256"
             },
             "gps": {
                 "lat": 22.33804,
@@ -331,8 +350,9 @@
             "zone": 6,
             "image": "/boulders/slab-king/slab-king-1-3-w768w.jpg",
             "image_map": {
-                "coords": "743,304,19",
-                "shape": "circle"
+                "cx": "2969.9438",
+                "cy": "1209.4913",
+                "r": "68.214256"
             },
             "gps": {
                 "lat": 22.33806,
@@ -346,8 +366,9 @@
             "zone": 6,
             "image": "/boulders/the-submarine/the-submarine-1-x-w4032w.jpg",
             "image_map": {
-                "coords": "592,291,18",
-                "shape": "circle"
+                "cx": "2363.2629",
+                "cy": "1161.0188",
+                "r": "68.214256"
             },
             "gps": {
                 "lat": 22.33808,
@@ -361,8 +382,9 @@
             "zone": 7,
             "image": "/boulders/jip/jip-3-7-w3264w.jpg",
             "image_map": {
-                "coords": "884,216,18",
-                "shape": "circle"
+                "cx": "3528.7761",
+                "cy": "855.30188",
+                "r": "68.214256"
             },
             "gps": {
                 "lat": 22.3382,
@@ -376,8 +398,9 @@
             "zone": 8,
             "image": "/boulders/sam-and-frodo/sam-and-frodo-1-w4032w.jpg",
             "image_map": {
-                "coords": "590,92,16",
-                "shape": "circle"
+                "cx": "2346.2739",
+                "cy": "361.5658",
+                "r": "62.96701"
             },
             "gps": {
                 "lat": 22.3384,
@@ -391,8 +414,9 @@
             "zone": 8,
             "image": "/boulders/rock-slide/rock-slide-1-2-w3264w.jpg",
             "image_map": {
-                "coords": "579,145,19",
-                "shape": "circle"
+                "cx": "2319.2849",
+                "cy": "582.44482",
+                "r": "68.214256"
             },
             "gps": {
                 "lat": 22.33831,
@@ -406,8 +430,9 @@
             "zone": 8,
             "image": "/boulders/radiance/radiance-1-2-w4032w.jpg",
             "image_map": {
-                "coords": "559,74,17",
-                "shape": "circle"
+                "cx": "2241.8232",
+                "cy": "297.09329",
+                "r": "57.719757"
             },
             "gps": {
                 "lat": 22.33842,
@@ -421,8 +446,9 @@
             "zone": 8,
             "image": "/boulders/sunfire/sunfire-1-3-w4100w.JPG",
             "image_map": {
-                "coords": "474,83,16",
-                "shape": "circle"
+                "cx": "1899.5048",
+                "cy": "330.57681",
+                "r": "62.96701"
             },
             "gps": {
                 "lat": 22.33841,
@@ -436,8 +462,9 @@
             "zone": 8,
             "image": "/boulders/rakia/rakia-1-4-w3264w.jpg",
             "image_map": {
-                "coords": "643,70,15",
-                "shape": "circle"
+                "cx": "2575.0237",
+                "cy": "280.10428",
+                "r": "62.96701"
             },
             "gps": {
                 "lat": 22.33843,
@@ -451,8 +478,9 @@
             "zone": 8,
             "image": "/boulders/behind-rakia/behind-rakia-1-2-w3024w.jpg",
             "image_map": {
-                "coords": "667,90,16",
-                "shape": "circle"
+                "cx": "2672.2271",
+                "cy": "362.18942",
+                "r": "62.96701"
             },
             "gps": {
                 "lat": 22.3384,
@@ -466,8 +494,9 @@
             "zone": 8,
             "image": "/boulders/left-of-rakia/left-of-rakia-1-2-w3264w.jpg",
             "image_map": {
-                "coords": "611,64,17",
-                "shape": "circle"
+                "cx": "2434.7244",
+                "cy": "253.244,42",
+                "r": "65.591003"
             },
             "gps": {
                 "lat": 22.33844,

--- a/app/data/boulders.json
+++ b/app/data/boulders.json
@@ -6,6 +6,10 @@
             "id": "0.1",
             "zone": 0,
             "image": "/boulders/beginner/beginner-1-2-w2529w.jpg",
+            "image_map": {
+                "coords": "1010,837,20",
+                "shape": "circle"
+            },
             "access": {
                 "link": "https://www.instagram.com/reel/CzXerSWSeYH/?utm_source=ig_web_copy_link&igshid=MzRlODBiNWFlZA==",
                 "text": "Access",
@@ -23,6 +27,10 @@
             "id": "1.1",
             "zone": 1,
             "image": "/boulders/welcome/welcome-w2826w.jpg",
+            "image_map": {
+                "coords": "533,788,18",
+                "shape": "circle"
+            },
             "gps": {
                 "lat": 22.33729,
                 "lng": 114.21805
@@ -34,6 +42,10 @@
             "id": "1.2",
             "zone": 1,
             "image": "/boulders/the-crown/the-crown-1-2-w2305w.jpg",
+            "image_map": {
+                "coords": "592,681,20",
+                "shape": "circle"
+            },
             "gps": {
                 "lat": 22.33746,
                 "lng": 114.21815
@@ -45,6 +57,10 @@
             "id": "1.3",
             "zone": 1,
             "image": "/boulders/spectral/spectral-1-4-w3476w.jpg",
+            "image_map": {
+                "coords": "627,648,18",
+                "shape": "circle"
+            },
             "gps": {
                 "lat": 22.33751,
                 "lng": 114.21821
@@ -56,6 +72,10 @@
             "id": "1.4",
             "zone": 1,
             "image": "/boulders/viking-table/viking-table-1-w3264w.jpg",
+            "image_map": {
+                "coords": "603,548,18",
+                "shape": "circle"
+            },
             "gps": {
                 "lat": 22.33767,
                 "lng": 114.21817
@@ -67,6 +87,10 @@
             "id": "1.5",
             "zone": 1,
             "image": "/boulders/tiny/tiny-1-w3024w.jpg",
+            "image_map": {
+                "coords": "509,473,20",
+                "shape": "circle"
+            },
             "gps": {
                 "lat": 22.33779,
                 "lng": 114.21801
@@ -78,6 +102,10 @@
             "id": "1.6",
             "zone": 1,
             "image": "/boulders/temple/temple-1-w2305w.jpg",
+            "image_map": {
+                "coords": "434,681,18",
+                "shape": "circle"
+            },
             "gps": {
                 "lat": 22.33746,
                 "lng": 114.21788
@@ -89,6 +117,10 @@
             "id": "2.1",
             "zone": 2,
             "image": "/boulders/frost/frost-1-2-w4032w.jpg",
+            "image_map": {
+                "coords": "428,347,17",
+                "shape": "circle"
+            },
             "gps": {
                 "lat": 22.33798,
                 "lng": 114.21787
@@ -100,6 +132,10 @@
             "id": "2.2",
             "zone": 2,
             "image": "/boulders/iron-wing/iron-wing-1-w3024w.jpg",
+            "image_map": {
+                "coords": "429,383,15",
+                "shape": "circle"
+            },
             "gps": {
                 "lat": 22.33794,
                 "lng": 114.21787
@@ -111,6 +147,10 @@
             "id": "2.3",
             "zone": 2,
             "image": "/boulders/the-whale/the-whale-1-4-w4032w.jpg",
+            "image_map": {
+                "coords": "440,310,18",
+                "shape": "circle"
+            },
             "gps": {
                 "lat": 22.33805,
                 "lng": 114.21789
@@ -122,6 +162,10 @@
             "id": "3.1",
             "zone": 3,
             "image": "/boulders/falcon/falcon-1-2-w4032w.jpg",
+            "image_map": {
+                "coords": "390,449,19",
+                "shape": "circle"
+            },
             "gps": {
                 "lat": 22.33783,
                 "lng": 114.2178
@@ -133,6 +177,10 @@
             "id": "3.2",
             "zone": 3,
             "image": "/boulders/dragon-head/dragon-head-1-2-w2305w.jpg",
+            "image_map": {
+                "coords": "400,487,18",
+                "shape": "circle"
+            },
             "gps": {
                 "lat": 22.33777,
                 "lng": 114.21782
@@ -151,6 +199,10 @@
             "id": "4.1",
             "zone": 4,
             "image": "/boulders/destiny/destiny-2-5-w3264w.jpg",
+            "image_map": {
+                "coords": "132,422,19",
+                "shape": "circle"
+            },
             "access": {
                 "link": "https://www.instagram.com/reel/CzNvNbjSm3p/?utm_source=ig_web_copy_link&igshid=MzRlODBiNWFlZA==",
                 "text": "Access",
@@ -168,6 +220,10 @@
             "id": "4.2",
             "zone": 4,
             "image": "/boulders/wuji/wuji-1-w2448w.jpg",
+            "image_map": {
+                "coords": "295,336,19",
+                "shape": "circle"
+            },
             "gps": {
                 "lat": 22.33801,
                 "lng": 114.21764
@@ -179,6 +235,10 @@
             "id": "5.1",
             "zone": 5,
             "image": "/boulders/kaze/kaze-1-w4032w.jpg",
+            "image_map": {
+                "coords": "800,568,18",
+                "shape": "circle"
+            },
             "gps": {
                 "lat": 22.33764,
                 "lng": 114.21851
@@ -204,6 +264,10 @@
                 }
             ],
             "image": "/boulders/the-three-artifacts/the-three-artifacts-4-6-w4032w.jpeg",
+            "image_map": {
+                "coords": "910,492,17",
+                "shape": "circle"
+            },
             "gps": {
                 "lat": 22.33776,
                 "lng": 114.2187
@@ -215,6 +279,10 @@
             "id": "6.1",
             "zone": 6,
             "image": "/boulders/strength/strength-1-w4032w.jpg",
+            "image_map": {
+                "coords": "650,233,19",
+                "shape": "circle"
+            },
             "gps": {
                 "lat": 22.33817,
                 "lng": 114.21825
@@ -226,6 +294,10 @@
             "id": "6.2",
             "zone": 6,
             "image": "/boulders/the-great-sail/the-great-sail-3-4-w4032w.jpg",
+            "image_map": {
+                "coords": "814,380,21",
+                "shape": "circle"
+            },
             "access": {
                 "link": "https://www.instagram.com/reel/CzNgP9fyiLs/?utm_source=ig_web_copy_link&igshid=MzRlODBiNWFlZA==",
                 "text": "Access",
@@ -243,6 +315,10 @@
             "id": "6.3",
             "zone": 6,
             "image": "/boulders/ghost-blade/ghost-blade-1-3-w4032w.jpg",
+            "image_map": {
+                "coords": "831,316,17",
+                "shape": "circle"
+            },
             "gps": {
                 "lat": 22.33804,
                 "lng": 114.21856
@@ -254,6 +330,10 @@
             "id": "6.4",
             "zone": 6,
             "image": "/boulders/slab-king/slab-king-1-3-w768w.jpg",
+            "image_map": {
+                "coords": "743,304,19",
+                "shape": "circle"
+            },
             "gps": {
                 "lat": 22.33806,
                 "lng": 114.21841
@@ -265,6 +345,10 @@
             "id": "6.5",
             "zone": 6,
             "image": "/boulders/the-submarine/the-submarine-1-x-w4032w.jpg",
+            "image_map": {
+                "coords": "592,291,18",
+                "shape": "circle"
+            },
             "gps": {
                 "lat": 22.33808,
                 "lng": 114.21815
@@ -276,6 +360,10 @@
             "id": "7.1",
             "zone": 7,
             "image": "/boulders/jip/jip-3-7-w3264w.jpg",
+            "image_map": {
+                "coords": "884,216,18",
+                "shape": "circle"
+            },
             "gps": {
                 "lat": 22.3382,
                 "lng": 114.21865
@@ -287,6 +375,10 @@
             "id": "8.1",
             "zone": 8,
             "image": "/boulders/sam-and-frodo/sam-and-frodo-1-w4032w.jpg",
+            "image_map": {
+                "coords": "590,92,16",
+                "shape": "circle"
+            },
             "gps": {
                 "lat": 22.3384,
                 "lng": 114.21814
@@ -298,6 +390,10 @@
             "id": "8.2",
             "zone": 8,
             "image": "/boulders/rock-slide/rock-slide-1-2-w3264w.jpg",
+            "image_map": {
+                "coords": "579,145,19",
+                "shape": "circle"
+            },
             "gps": {
                 "lat": 22.33831,
                 "lng": 114.21813
@@ -309,6 +405,10 @@
             "id": "8.3",
             "zone": 8,
             "image": "/boulders/radiance/radiance-1-2-w4032w.jpg",
+            "image_map": {
+                "coords": "559,74,17",
+                "shape": "circle"
+            },
             "gps": {
                 "lat": 22.33842,
                 "lng": 114.2181
@@ -320,6 +420,10 @@
             "id": "8.4",
             "zone": 8,
             "image": "/boulders/sunfire/sunfire-1-3-w4100w.JPG",
+            "image_map": {
+                "coords": "474,83,16",
+                "shape": "circle"
+            },
             "gps": {
                 "lat": 22.33841,
                 "lng": 114.21795
@@ -331,8 +435,12 @@
             "id": "8.5",
             "zone": 8,
             "image": "/boulders/rakia/rakia-1-4-w3264w.jpg",
+            "image_map": {
+                "coords": "643,70,15",
+                "shape": "circle"
+            },
             "gps": {
-                "lat": 22.33843, 
+                "lat": 22.33843,
                 "lng": 114.21824
             }
         },
@@ -342,8 +450,12 @@
             "id": "8.6",
             "zone": 8,
             "image": "/boulders/behind-rakia/behind-rakia-1-2-w3024w.jpg",
+            "image_map": {
+                "coords": "667,90,16",
+                "shape": "circle"
+            },
             "gps": {
-                "lat": 22.3384, 
+                "lat": 22.3384,
                 "lng": 114.21828
             }
         },
@@ -353,6 +465,10 @@
             "id": "8.7",
             "zone": 8,
             "image": "/boulders/left-of-rakia/left-of-rakia-1-2-w3264w.jpg",
+            "image_map": {
+                "coords": "611,64,17",
+                "shape": "circle"
+            },
             "gps": {
                 "lat": 22.33844,
                 "lng": 114.21818

--- a/app/data/boulders.json
+++ b/app/data/boulders.json
@@ -495,7 +495,7 @@
             "image": "/boulders/left-of-rakia/left-of-rakia-1-2-w3264w.jpg",
             "image_map": {
                 "cx": "2434.7244",
-                "cy": "253.244,42",
+                "cy": "253.24442",
                 "r": "65.591003"
             },
             "gps": {

--- a/app/page.js
+++ b/app/page.js
@@ -1,3 +1,4 @@
+import boulders from '@/app/data/boulders.json'
 import Image from './_components/Image'
 import styles from './page.module.scss'
 
@@ -8,7 +9,20 @@ export default function Home() {
                 <h2>CRAGS.HK</h2>
                 <h1>Your Complete Guide to Bouldering and Climbing in Sunset Forest</h1>
                 <div className="map">
-                    <Image path="/common/sunset-forest-phase1a-w4800w.jpg" alt="Sunset Forest Bouldering Site Map | CRAGS.HK" />
+                    <Image hideFullView={true} path="/common/sunset-forest-phase1a-w4800w.jpg" alt="Sunset Forest Bouldering Site Map | CRAGS.HK" useMap="#image-map" />
+                    <map name="image-map">
+                        {boulders.data.filter((boulder) => boulder.image_map?.coords).map((boulder) => {
+                            // ImageMap coords were generated from https://www.image-map.net/ using the resized smaller image
+                            // FIXME: Only circle & rectangle are supported
+                            // TODO: Use library to handle responsive resize
+                            let { image_map: { coords: coords } } = boulder
+                            let [x, y, radius] = coords.split(",").map((v) => parseInt(v))
+                            let ratio = 1 / 1200 * 640
+                            let resized_x = Math.round(x * ratio)
+                            let resized_y = Math.round(y * ratio)
+                            return <area target="_blank" coords={`${resized_x},${resized_y},${radius}`} shape={boulder.image_map.shape} alt={`${boulder.id} ${boulder.name}`} title={`${boulder.id} ${boulder.name}`} href={`/sunset-forest/boulder/${boulder.slug}`} />;
+                        })}
+                    </map>
                 </div>
                 <p>Explore Sunset Forest, one of the premier bouldering and climbing sites in Hong Kong, all at your fingertips. At CRAGS.HK, we provide comprehensive access to detailed guides and information based on boulders, grades, and ratings, all segmented by specific zones within Sunset Forest.</p>
                 <p>Through our platform, you can enjoy minimal data usage and swift browsing speed, making it easy for you to get the latest updates and plan your climbing or bouldering adventure effortlessly. Even in areas with poor signal or when you're running low on data, we've designed our online guidebook to be easily accessible, anytime, anywhere.</p>

--- a/app/page.js
+++ b/app/page.js
@@ -1,5 +1,4 @@
-import boulders from '@/app/data/boulders.json'
-import Image from './_components/Image'
+import ImageMap from './_components/ImageMap'
 import styles from './page.module.scss'
 
 export default function Home() {
@@ -9,20 +8,7 @@ export default function Home() {
                 <h2>CRAGS.HK</h2>
                 <h1>Your Complete Guide to Bouldering and Climbing in Sunset Forest</h1>
                 <div className="map">
-                    <Image hideFullView={true} path="/common/sunset-forest-phase1a-w4800w.jpg" alt="Sunset Forest Bouldering Site Map | CRAGS.HK" useMap="#image-map" />
-                    <map name="image-map">
-                        {boulders.data.filter((boulder) => boulder.image_map?.coords).map((boulder) => {
-                            // ImageMap coords were generated from https://www.image-map.net/ using the resized smaller image
-                            // FIXME: Only circle & rectangle are supported
-                            // TODO: Use library to handle responsive resize
-                            let { image_map: { coords: coords } } = boulder
-                            let [x, y, radius] = coords.split(",").map((v) => parseInt(v))
-                            let ratio = 1 / 1200 * 640
-                            let resized_x = Math.round(x * ratio)
-                            let resized_y = Math.round(y * ratio)
-                            return <area target="_blank" coords={`${resized_x},${resized_y},${radius}`} shape={boulder.image_map.shape} alt={`${boulder.id} ${boulder.name}`} title={`${boulder.id} ${boulder.name}`} href={`/sunset-forest/boulder/${boulder.slug}`} />;
-                        })}
-                    </map>
+                    <ImageMap path="/common/sunset-forest-phase1a-w4800w.jpg" alt="Sunset Forest Bouldering Site Map | CRAGS.HK" />
                 </div>
                 <p>Explore Sunset Forest, one of the premier bouldering and climbing sites in Hong Kong, all at your fingertips. At CRAGS.HK, we provide comprehensive access to detailed guides and information based on boulders, grades, and ratings, all segmented by specific zones within Sunset Forest.</p>
                 <p>Through our platform, you can enjoy minimal data usage and swift browsing speed, making it easy for you to get the latest updates and plan your climbing or bouldering adventure effortlessly. Even in areas with poor signal or when you're running low on data, we've designed our online guidebook to be easily accessible, anytime, anywhere.</p>
@@ -32,6 +18,6 @@ export default function Home() {
                 <h3><a href="https://maps.app.goo.gl/imrdXQzcdumx23VM6" target="_blank" title="Access & Location in Google Map | Complete Guide to Bouldering and Climbing in Sunset Forest | CRAGS.HK">Access</a></h3>
                 <p>We already created a Google marker of Sunset Forest, please click <a href="https://maps.app.goo.gl/imrdXQzcdumx23VM6" target="_blank" title="Access & Location in Google Map | Complete Guide to Bouldering and Climbing in Sunset Forest | CRAGS.HK">here</a> to check the location</p>
             </div>
-        </main>
+        </main >
     )
 }

--- a/public/images/common/sunset-forest-phase1a-w4800w-min.svg
+++ b/public/images/common/sunset-forest-phase1a-w4800w-min.svg
@@ -1,0 +1,203 @@
+<svg
+   version="1.1"
+   id="svg1"
+   viewBox="0 0 4800 4132"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <g id="g1">
+    <image
+       width="4800"
+       height="4132"
+       style="image-rendering:optimizeSpeed;fill:#ffffff;fill-opacity:1"
+       xlink:href="sunset-forest-phase1a-w4800w.jpg"
+       id="image1" />
+    <a
+       id="a30"
+       xlink:href="https://crags.hk/sunset-forest/boulder/beginner/"
+       xlink:title="0.1 Beginner"
+       target="_blank">
+      <circle
+         style="opacity:0.494;fill:#ffffff;fill-opacity:1"
+         id="path1"
+         cx="4041.7595"
+         cy="3348.4988"
+         r="78.708763" />
+    </a>
+    <circle
+       style="opacity:0.494;fill:#ffffff;fill-opacity:1"
+       id="path2"
+       cx="2131.7603"
+       cy="3149.1033"
+       r="76.085136" />
+    <circle
+       style="opacity:0.494;fill:#ffffff;fill-opacity:1"
+       id="path3"
+       cx="2363.2629"
+       cy="2719.4521"
+       r="70.837883" />
+    <circle
+       style="opacity:0.494;fill:#ffffff;fill-opacity:1"
+       id="path4"
+       cx="2502.3149"
+       cy="2592.8945"
+       r="76.085136" />
+    <ellipse
+       style="opacity:0.494;fill:#ffffff;fill-opacity:1;stroke-width:0.936979"
+       id="path5"
+       cx="2407.8645"
+       cy="2192.1035"
+       rx="76.085136"
+       ry="81.332382" />
+    <circle
+       style="opacity:0.494;fill:#ffffff;fill-opacity:1"
+       id="path6"
+       cx="2037.9333"
+       cy="1887.1394"
+       r="83.956009" />
+    <circle
+       style="opacity:0.494;fill:#ffffff;fill-opacity:1"
+       id="path7"
+       cx="1731.5928"
+       cy="2715.4521"
+       r="78.708763" />
+    <circle
+       style="opacity:0.494;fill:#ffffff;fill-opacity:1"
+       id="path8"
+       cx="1713.9801"
+       cy="1390.2632"
+       r="76.085136" />
+    <circle
+       style="opacity:0.494;fill:#ffffff;fill-opacity:1"
+       id="path9"
+       cx="1711.2274"
+       cy="1538.4554"
+       r="73.46151" />
+    <circle
+       style="opacity:0.494;fill:#ffffff;fill-opacity:1"
+       id="path10"
+       cx="1759.2053"
+       cy="1234.4803"
+       r="76.085136" />
+    <circle
+       style="opacity:0.494;fill:#ffffff;fill-opacity:1"
+       id="path11"
+       cx="1548.5626"
+       cy="1789.9362"
+       r="78.708763" />
+    <circle
+       style="opacity:0.494;fill:#ffffff;fill-opacity:1"
+       id="path12"
+       cx="1594.5406"
+       cy="1940.8591"
+       r="76.085136" />
+    <circle
+       style="opacity:0.494;fill:#ffffff;fill-opacity:1"
+       id="path13"
+       cx="525.47784"
+       cy="1688.3674"
+       r="73.46151" />
+    <circle
+       style="opacity:0.494;fill:#ffffff;fill-opacity:1"
+       id="path14"
+       cx="1176.7605"
+       cy="1336.1781"
+       r="76.085136" />
+    <circle
+       style="opacity:0.494;fill:#ffffff;fill-opacity:1"
+       id="path15"
+       cx="3200.823"
+       cy="2267.5652"
+       r="70.837883" />
+    <circle
+       style="opacity:0.494;fill:#ffffff;fill-opacity:1"
+       id="path16"
+       cx="3646.8394"
+       cy="1965.0955"
+       r="68.214256" />
+    <circle
+       style="opacity:0.494;fill:#ffffff;fill-opacity:1"
+       id="path17"
+       cx="2597.3892"
+       cy="934.01062"
+       r="68.214256" />
+    <circle
+       style="opacity:0.494;fill:#ffffff;fill-opacity:1"
+       id="path18"
+       cx="3248.6719"
+       cy="1512.5846"
+       r="68.214256" />
+    <circle
+       style="opacity:0.494;fill:#ffffff;fill-opacity:1"
+       id="path19"
+       cx="3318.886"
+       cy="1259.3402"
+       r="68.214256" />
+    <circle
+       style="opacity:0.494;fill:#ffffff;fill-opacity:1"
+       id="path20"
+       cx="2969.9438"
+       cy="1209.4913"
+       r="68.214256" />
+    <circle
+       style="opacity:0.494;fill:#ffffff;fill-opacity:1"
+       id="path21"
+       cx="2363.2629"
+       cy="1161.0188"
+       r="68.214256" />
+    <circle
+       style="opacity:0.494;fill:#ffffff;fill-opacity:1"
+       id="path22"
+       cx="3528.7761"
+       cy="855.30188"
+       r="68.214256" />
+    <circle
+       style="opacity:0.494;fill:#ffffff;fill-opacity:1"
+       id="path23"
+       cx="2346.2739"
+       cy="361.5658"
+       r="62.96701" />
+    <circle
+       style="opacity:0.494;fill:#ffffff;fill-opacity:1"
+       id="path24"
+       cx="2319.2849"
+       cy="582.44482"
+       r="68.214256" />
+    <circle
+       style="opacity:0.494;fill:#ffffff;fill-opacity:1"
+       id="path25"
+       cx="2241.8232"
+       cy="297.09329"
+       r="57.719757" />
+    <circle
+       style="opacity:0.494;fill:#ffffff;fill-opacity:1"
+       id="path26"
+       cx="1899.5048"
+       cy="330.57681"
+       r="62.96701" />
+    <circle
+       style="opacity:0.494;fill:#ffffff;fill-opacity:1"
+       id="path27"
+       cx="2575.0237"
+       cy="280.10428"
+       r="62.96701" />
+    <circle
+       style="opacity:0.494;fill:#ffffff;fill-opacity:1"
+       id="path28"
+       cx="2672.2271"
+       cy="362.18942"
+       r="62.96701" />
+    <a
+       id="a29"
+       xlink:title="8.7 Left of Rakia&#10;"
+       xlink:href="https://crags.hk/sunset-forest/boulder/left-of-rakia/"
+       target="_blank">
+      <circle
+         style="opacity:0;fill:#ffffff;fill-opacity:1"
+         id="path29"
+         cx="2434.7244"
+         cy="253.24442"
+         r="65.591003" />
+    </a>
+  </g>
+</svg>

--- a/public/images/common/sunset-forest-phase1a-w4800w.svg
+++ b/public/images/common/sunset-forest-phase1a-w4800w.svg
@@ -1,0 +1,245 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   version="1.1"
+   id="svg1"
+   width="4800"
+   height="4132"
+   viewBox="0 0 4800 4132"
+   sodipodi:docname="sunset-forest-phase1a-w4800w.svg"
+   inkscape:version="1.3.1 (91b66b0, 2023-11-16)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <g
+     inkscape:groupmode="layer"
+     inkscape:label="Image"
+     id="g1">
+    <image
+       width="4800"
+       height="4132"
+       style="image-rendering:optimizeSpeed;fill:#ffffff;fill-opacity:1"
+       xlink:href="sunset-forest-phase1a-w4800w.jpg"
+       id="image1" />
+    <a
+       id="a30"
+       xlink:href="https://crags.hk/sunset-forest/boulder/beginner/"
+       xlink:title="0.1 Beginner"
+       target="_blank">
+      <circle
+         style="opacity:0.494;fill:#ffffff;fill-opacity:1"
+         id="path1"
+         cx="4041.7595"
+         cy="3348.4988"
+         r="78.708763"
+         inkscape:label="0.1" />
+    </a>
+    <circle
+       style="opacity:0.494;fill:#ffffff;fill-opacity:1"
+       id="path2"
+       cx="2131.7603"
+       cy="3149.1033"
+       r="76.085136"
+       inkscape:label="1.1" />
+    <circle
+       style="opacity:0.494;fill:#ffffff;fill-opacity:1"
+       id="path3"
+       cx="2363.2629"
+       cy="2719.4521"
+       r="70.837883"
+       inkscape:label="1.2" />
+    <circle
+       style="opacity:0.494;fill:#ffffff;fill-opacity:1"
+       id="path4"
+       cx="2502.3149"
+       cy="2592.8945"
+       r="76.085136"
+       inkscape:label="1.3" />
+    <ellipse
+       style="opacity:0.494;fill:#ffffff;fill-opacity:1;stroke-width:0.936979"
+       id="path5"
+       cx="2407.8645"
+       cy="2192.1035"
+       rx="76.085136"
+       ry="81.332382"
+       inkscape:label="1.4" />
+    <circle
+       style="opacity:0.494;fill:#ffffff;fill-opacity:1"
+       id="path6"
+       cx="2037.9333"
+       cy="1887.1394"
+       r="83.956009"
+       inkscape:label="1.5" />
+    <circle
+       style="opacity:0.494;fill:#ffffff;fill-opacity:1"
+       id="path7"
+       cx="1731.5928"
+       cy="2715.4521"
+       r="78.708763"
+       inkscape:label="1.6" />
+    <circle
+       style="opacity:0.494;fill:#ffffff;fill-opacity:1"
+       id="path8"
+       cx="1713.9801"
+       cy="1390.2632"
+       r="76.085136"
+       inkscape:label="2.1" />
+    <circle
+       style="opacity:0.494;fill:#ffffff;fill-opacity:1"
+       id="path9"
+       cx="1711.2274"
+       cy="1538.4554"
+       r="73.46151"
+       inkscape:label="2.2" />
+    <circle
+       style="opacity:0.494;fill:#ffffff;fill-opacity:1"
+       id="path10"
+       cx="1759.2053"
+       cy="1234.4803"
+       r="76.085136"
+       inkscape:label="2.3" />
+    <circle
+       style="opacity:0.494;fill:#ffffff;fill-opacity:1"
+       id="path11"
+       cx="1548.5626"
+       cy="1789.9362"
+       r="78.708763"
+       inkscape:label="3.1" />
+    <circle
+       style="opacity:0.494;fill:#ffffff;fill-opacity:1"
+       id="path12"
+       cx="1594.5406"
+       cy="1940.8591"
+       r="76.085136"
+       inkscape:label="3.2" />
+    <circle
+       style="opacity:0.494;fill:#ffffff;fill-opacity:1"
+       id="path13"
+       cx="525.47784"
+       cy="1688.3674"
+       r="73.46151"
+       inkscape:label="4.1" />
+    <circle
+       style="opacity:0.494;fill:#ffffff;fill-opacity:1"
+       id="path14"
+       cx="1176.7605"
+       cy="1336.1781"
+       r="76.085136"
+       inkscape:label="4.2" />
+    <circle
+       style="opacity:0.494;fill:#ffffff;fill-opacity:1"
+       id="path15"
+       cx="3200.823"
+       cy="2267.5652"
+       r="70.837883"
+       inkscape:label="5.1" />
+    <circle
+       style="opacity:0.494;fill:#ffffff;fill-opacity:1"
+       id="path16"
+       cx="3646.8394"
+       cy="1965.0955"
+       r="68.214256"
+       inkscape:label="5.2" />
+    <circle
+       style="opacity:0.494;fill:#ffffff;fill-opacity:1"
+       id="path17"
+       cx="2597.3892"
+       cy="934.01062"
+       r="68.214256"
+       inkscape:label="6.1" />
+    <circle
+       style="opacity:0.494;fill:#ffffff;fill-opacity:1"
+       id="path18"
+       cx="3248.6719"
+       cy="1512.5846"
+       r="68.214256"
+       inkscape:label="6.2" />
+    <circle
+       style="opacity:0.494;fill:#ffffff;fill-opacity:1"
+       id="path19"
+       cx="3318.886"
+       cy="1259.3402"
+       r="68.214256"
+       inkscape:label="6.3" />
+    <circle
+       style="opacity:0.494;fill:#ffffff;fill-opacity:1"
+       id="path20"
+       cx="2969.9438"
+       cy="1209.4913"
+       r="68.214256"
+       inkscape:label="6.4" />
+    <circle
+       style="opacity:0.494;fill:#ffffff;fill-opacity:1"
+       id="path21"
+       cx="2363.2629"
+       cy="1161.0188"
+       r="68.214256"
+       inkscape:label="6.5" />
+    <circle
+       style="opacity:0.494;fill:#ffffff;fill-opacity:1"
+       id="path22"
+       cx="3528.7761"
+       cy="855.30188"
+       r="68.214256"
+       inkscape:label="7.1" />
+    <circle
+       style="opacity:0.494;fill:#ffffff;fill-opacity:1"
+       id="path23"
+       cx="2346.2739"
+       cy="361.5658"
+       r="62.96701"
+       inkscape:label="8.1" />
+    <circle
+       style="opacity:0.494;fill:#ffffff;fill-opacity:1"
+       id="path24"
+       cx="2319.2849"
+       cy="582.44482"
+       r="68.214256"
+       inkscape:label="8.2" />
+    <circle
+       style="opacity:0.494;fill:#ffffff;fill-opacity:1"
+       id="path25"
+       cx="2241.8232"
+       cy="297.09329"
+       r="57.719757"
+       inkscape:label="8.3" />
+    <circle
+       style="opacity:0.494;fill:#ffffff;fill-opacity:1"
+       id="path26"
+       cx="1899.5048"
+       cy="330.57681"
+       r="62.96701"
+       inkscape:label="8.4" />
+    <circle
+       style="opacity:0.494;fill:#ffffff;fill-opacity:1"
+       id="path27"
+       cx="2575.0237"
+       cy="280.10428"
+       r="62.96701"
+       inkscape:label="8.5" />
+    <circle
+       style="opacity:0.494;fill:#ffffff;fill-opacity:1"
+       id="path28"
+       cx="2672.2271"
+       cy="362.18942"
+       r="62.96701"
+       inkscape:label="8.6" />
+    <a
+       id="a29"
+       xlink:title="8.7 Left of Rakia&#10;"
+       xlink:href="https://crags.hk/sunset-forest/boulder/left-of-rakia/"
+       target="_blank">
+      <circle
+         style="opacity:0;fill:#ffffff;fill-opacity:1"
+         id="path29"
+         cx="2434.7244"
+         cy="253.24442"
+         r="65.591003" 
+         inkscape:label="8.7"
+         />
+    </a>
+  </g>
+</svg>


### PR DESCRIPTION
## What

Add image map using SVG (for responsible resizing) to allow navigating to boulder page from the Map page (home page).

## Feature

Climbers asked for whether its possible top being about to traverse to different boulder by climbing Map image directly, since tapping multiple times via the Menu -> Boulders -> by number is too annoying.

## How

Used Inkscape to create the initial SVG (see the checked in `.svg` file) image map.

## Test

Local only. No performance test is run since there is no guideline for it.

### Mobile view

![sunset-test-mobile](https://github.com/alextsoi/2310-crags-hk/assets/51911598/76b35263-8fb9-4f5b-b369-ed963addc792)

### Desktop view

![sunset-test-desktop](https://github.com/alextsoi/2310-crags-hk/assets/51911598/f3f4619b-2fc8-40c6-a3fc-3c4d02c43f0d)
